### PR TITLE
[feat] Admittance Controller & Variable stiffness support

### DIFF
--- a/crisp_py/config/control/default_admittance.yaml
+++ b/crisp_py/config/control/default_admittance.yaml
@@ -1,20 +1,39 @@
 # Default admittance controller parameters
-# Impedance outer loop (task stiffness/damping for the Cartesian impedance controller)
-task.k_pos_x: 600.0
-task.k_pos_y: 600.0
-task.k_pos_z: 600.0
+
+# Impedance outer loop
+limit_error: true
+limit_torques: true
+max_delta_tau: 2.0
+nullspace.stiffness: 5.0
+stop_commands: false
+
+task.k_pos_x: 900.0
+task.k_pos_y: 900.0
+task.k_pos_z: 900.0
+task.k_rot_x: 45.0
+task.k_rot_y: 45.0
+task.k_rot_z: 45.0
+
 task.d_pos_x: 60.0
 task.d_pos_y: 60.0
 task.d_pos_z: 60.0
-task.k_rot_x: 30.0
-task.k_rot_y: 30.0
-task.k_rot_z: 30.0
 task.d_rot_x: 10.0
 task.d_rot_y: 10.0
 task.d_rot_z: 10.0
-use_gravity_compensation: false
+
+task.error_clip.rx: 0.5
+task.error_clip.ry: 0.5
+task.error_clip.rz: 0.5
+task.error_clip.x: 0.1
+task.error_clip.y: 0.1
+task.error_clip.z: 0.1
+
 use_coriolis_compensation: true
 use_friction: true
+use_gravity_compensation: false
+use_local_jacobian: true
+use_operational_space: false
+
 # Admittance parameters (virtual MSD)
 admittance.mass_x: 1.0
 admittance.mass_y: 1.0
@@ -34,7 +53,6 @@ admittance.damping_z: 50.0
 admittance.damping_rx: 5.0
 admittance.damping_ry: 5.0
 admittance.damping_rz: 5.0
+
 # F/T sensor
 ft_sensor.topic: "ft_sensor_wrench"
-ft_sensor.filter_alpha: 0.1
-ft_sensor.use_static_offset: false

--- a/crisp_py/config/control/default_admittance.yaml
+++ b/crisp_py/config/control/default_admittance.yaml
@@ -1,0 +1,40 @@
+# Default admittance controller parameters
+# Impedance outer loop (task stiffness/damping for the Cartesian impedance controller)
+task.k_pos_x: 600.0
+task.k_pos_y: 600.0
+task.k_pos_z: 600.0
+task.d_pos_x: 60.0
+task.d_pos_y: 60.0
+task.d_pos_z: 60.0
+task.k_rot_x: 30.0
+task.k_rot_y: 30.0
+task.k_rot_z: 30.0
+task.d_rot_x: 10.0
+task.d_rot_y: 10.0
+task.d_rot_z: 10.0
+use_gravity_compensation: false
+use_coriolis_compensation: true
+use_friction: true
+# Admittance parameters (virtual MSD)
+admittance.mass_x: 1.0
+admittance.mass_y: 1.0
+admittance.mass_z: 1.0
+admittance.mass_rx: 0.1
+admittance.mass_ry: 0.1
+admittance.mass_rz: 0.1
+admittance.stiffness_x: 200.0
+admittance.stiffness_y: 200.0
+admittance.stiffness_z: 200.0
+admittance.stiffness_rx: 10.0
+admittance.stiffness_ry: 10.0
+admittance.stiffness_rz: 10.0
+admittance.damping_x: 50.0
+admittance.damping_y: 50.0
+admittance.damping_z: 50.0
+admittance.damping_rx: 5.0
+admittance.damping_ry: 5.0
+admittance.damping_rz: 5.0
+# F/T sensor
+ft_sensor.topic: "ft_sensor_wrench"
+ft_sensor.filter_alpha: 0.1
+ft_sensor.use_static_offset: false

--- a/crisp_py/config/robots/fr3_admittance.yaml
+++ b/crisp_py/config/robots/fr3_admittance.yaml
@@ -1,0 +1,2 @@
+robot_type: "franka"
+use_admittance_controller: true

--- a/crisp_py/robot/robot.py
+++ b/crisp_py/robot/robot.py
@@ -9,7 +9,6 @@ import rclpy
 import rclpy.executors
 import yaml
 from geometry_msgs.msg import PoseStamped, TwistStamped, WrenchStamped
-from std_msgs.msg import Float64MultiArray
 from numpy.typing import NDArray
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.node import Node
@@ -86,9 +85,11 @@ class Robot:
         self.joint_controller_parameters_client = ParametersClient(
             self.node, target_node=self.config.joint_trajectory_controller_name
         )
-        self.admittance_controller_parameters_client = ParametersClient(
-            self.node, target_node=self.config.cartesian_admittance_controller_name
-        )
+        self.admittance_controller_parameters_client = None
+        if self.config.use_admittance_controller:
+            self.admittance_controller_parameters_client = ParametersClient(
+                self.node, target_node=self.config.cartesian_admittance_controller_name
+            )
 
         self._current_pose = None
         self._target_pose = None
@@ -116,11 +117,13 @@ class Robot:
         self._target_joint_publisher = self.node.create_publisher(
             JointState, self.config.target_joint_topic, qos_profile_system_default
         )
-        self._target_admittance_stiffness_publisher = self.node.create_publisher(
-            Float64MultiArray,
-            self.config.target_admittance_stiffness_topic,
-            qos_profile_system_default,
-        )
+        self._target_admittance_stiffness_publisher = None
+        if self.config.use_admittance_controller:
+            self._target_admittance_stiffness_publisher = self.node.create_publisher(
+                Float64MultiArray,
+                self.config.target_admittance_stiffness_topic,
+                qos_profile_system_default,
+            )
         if self.config.use_tf_pose:
             self._tf_pose = TfPose(
                 self.node,
@@ -527,6 +530,11 @@ class Robot:
             translational: Stiffness values [kx, ky, kz] for position. If None, zeros are used.
             rotational: Stiffness values [krx, kry, krz] for orientation. If None, zeros are used.
         """
+        if self._target_admittance_stiffness_publisher is None:
+            raise RuntimeError(
+                "Admittance stiffness publishing is not enabled. "
+                "Set use_admittance_controller=true in the robot config."
+            )
         if translational is None:
             translational = [0.0, 0.0, 0.0]
         if rotational is None:

--- a/crisp_py/robot/robot.py
+++ b/crisp_py/robot/robot.py
@@ -9,6 +9,7 @@ import rclpy
 import rclpy.executors
 import yaml
 from geometry_msgs.msg import PoseStamped, TwistStamped, WrenchStamped
+from std_msgs.msg import Float64MultiArray
 from numpy.typing import NDArray
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.node import Node
@@ -85,6 +86,9 @@ class Robot:
         self.joint_controller_parameters_client = ParametersClient(
             self.node, target_node=self.config.joint_trajectory_controller_name
         )
+        self.admittance_controller_parameters_client = ParametersClient(
+            self.node, target_node=self.config.cartesian_admittance_controller_name
+        )
 
         self._current_pose = None
         self._target_pose = None
@@ -111,6 +115,11 @@ class Robot:
         )
         self._target_joint_publisher = self.node.create_publisher(
             JointState, self.config.target_joint_topic, qos_profile_system_default
+        )
+        self._target_admittance_stiffness_publisher = self.node.create_publisher(
+            Float64MultiArray,
+            self.config.target_admittance_stiffness_topic,
+            qos_profile_system_default,
         )
         if self.config.use_tf_pose:
             self._tf_pose = TfPose(
@@ -502,6 +511,33 @@ class Robot:
         msg = Float64MultiArray()
         msg.data = list(translational) + list(rotational)
         self._target_stiffness_publisher.publish(msg)
+
+    def set_admittance_stiffness(
+        self,
+        translational: List | NDArray | None = None,
+        rotational: List | NDArray | None = None,
+    ) -> None:
+        """Set the admittance stiffness for the admittance controller via topic.
+
+        This publishes an admittance stiffness update to the controller's variable
+        admittance stiffness topic. The value is latched by the controller.
+        Requires the controller parameter variable_admittance_stiffness.enabled to be true.
+
+        Args:
+            translational: Stiffness values [kx, ky, kz] for position. If None, zeros are used.
+            rotational: Stiffness values [krx, kry, krz] for orientation. If None, zeros are used.
+        """
+        if translational is None:
+            translational = [0.0, 0.0, 0.0]
+        if rotational is None:
+            rotational = [0.0, 0.0, 0.0]
+
+        assert len(translational) == 3, "Translational stiffness must be a 3D vector"
+        assert len(rotational) == 3, "Rotational stiffness must be a 3D vector"
+
+        msg = Float64MultiArray()
+        msg.data = list(translational) + list(rotational)
+        self._target_admittance_stiffness_publisher.publish(msg)
 
     def _wrench_to_wrench_msg(self, wrench: dict) -> WrenchStamped:
         """Convert a wrench dictionary to a ROS WrenchStamped message.

--- a/crisp_py/robot/robot_config.py
+++ b/crisp_py/robot/robot_config.py
@@ -43,7 +43,10 @@ class RobotConfig:
 
     default_controller: str = "cartesian_impedance_controller"
     cartesian_impedance_controller_name: str = "cartesian_impedance_controller"
+    cartesian_admittance_controller_name: str = "cartesian_admittance_controller"
     joint_trajectory_controller_name: str = "joint_impedance_controller"
+
+    target_admittance_stiffness_topic: str = "target_admittance_stiffness"
 
     target_pose_topic: str = "target_pose"
     target_joint_topic: str = "target_joint"

--- a/crisp_py/robot/robot_config.py
+++ b/crisp_py/robot/robot_config.py
@@ -65,6 +65,7 @@ class RobotConfig:
     tf_retrieve_rate: float = 50.0
 
     use_prefix: bool = False
+    use_admittance_controller: bool = False
 
     def num_joints(self) -> int:
         """Returns the number of joints in the robot."""

--- a/examples/22_admittance_variable_stiffness.py
+++ b/examples/22_admittance_variable_stiffness.py
@@ -1,0 +1,53 @@
+"""Example demonstrating variable admittance stiffness for the admittance controller.
+
+This script shows how to change the admittance stiffness at runtime. The robot
+maintains its position while the admittance compliance is changed from stiff
+(resists external forces) to compliant (yields to external forces).
+
+Requirements:
+    - cartesian_admittance_controller must be loaded and available
+    - variable_admittance_stiffness.enabled must be set to true
+    - An F/T sensor must be publishing on ft_sensor_wrench topic
+"""
+
+from crisp_py.robot import make_robot
+
+robot = make_robot("fr3")
+robot.wait_until_ready()
+
+# Switch to admittance controller
+robot.controller_switcher_client.switch_controller("cartesian_admittance_controller")
+
+# Load default admittance parameters
+robot.admittance_controller_parameters_client.load_param_config(
+    "config/control/default_admittance.yaml"
+)
+
+# Enable variable admittance stiffness
+robot.admittance_controller_parameters_client.set_parameters(
+    [("variable_admittance_stiffness.enabled", True)]
+)
+
+print("Admittance controller active. An F/T sensor is required.")
+print("Push the robot gently to feel the compliance change.")
+print()
+
+# High admittance stiffness (stiff - resists external forces)
+print("Setting HIGH admittance stiffness: translational=[500, 500, 500], rotational=[30, 30, 30]")
+print("The robot should feel stiff and resist external forces.")
+robot.set_admittance_stiffness(translational=[500.0, 500.0, 500.0], rotational=[30.0, 30.0, 30.0])
+input("Push the robot. Press Enter for MEDIUM stiffness...")
+
+# Medium admittance stiffness
+print("Setting MEDIUM admittance stiffness: translational=[100, 100, 100], rotational=[10, 10, 10]")
+print("The robot should be moderately compliant.")
+robot.set_admittance_stiffness(translational=[100.0, 100.0, 100.0], rotational=[10.0, 10.0, 10.0])
+input("Push the robot. Press Enter for LOW stiffness...")
+
+# Low admittance stiffness (compliant - yields to external forces)
+print("Setting LOW admittance stiffness: translational=[20, 20, 20], rotational=[2, 2, 2]")
+print("The robot should feel very compliant and yield to pushes.")
+robot.set_admittance_stiffness(translational=[20.0, 20.0, 20.0], rotational=[2.0, 2.0, 2.0])
+input("Push the robot. Press Enter to exit...")
+
+robot.shutdown()

--- a/examples/22_admittance_variable_stiffness.py
+++ b/examples/22_admittance_variable_stiffness.py
@@ -18,10 +18,10 @@ robot.wait_until_ready()
 # Switch to admittance controller
 robot.controller_switcher_client.switch_controller("cartesian_admittance_controller")
 
-# Load default admittance parameters
-robot.admittance_controller_parameters_client.load_param_config(
-    "config/control/default_admittance.yaml"
-)
+# # Load default admittance parameters
+# robot.admittance_controller_parameters_client.load_param_config(
+#     "config/control/default_admittance.yaml"
+# )
 
 # Enable variable admittance stiffness
 robot.admittance_controller_parameters_client.set_parameters(

--- a/examples/22_admittance_variable_stiffness.py
+++ b/examples/22_admittance_variable_stiffness.py
@@ -18,14 +18,9 @@ robot.wait_until_ready()
 # Switch to admittance controller
 robot.controller_switcher_client.switch_controller("cartesian_admittance_controller")
 
-# # Load default admittance parameters
-# robot.admittance_controller_parameters_client.load_param_config(
-#     "config/control/default_admittance.yaml"
-# )
-
-# Enable variable admittance stiffness
-robot.admittance_controller_parameters_client.set_parameters(
-    [("variable_admittance_stiffness.enabled", True)]
+# Load default admittance parameters
+robot.admittance_controller_parameters_client.load_param_config(
+    "config/control/default_admittance.yaml"
 )
 
 print("Admittance controller active. An F/T sensor is required.")

--- a/examples/22_admittance_variable_stiffness.py
+++ b/examples/22_admittance_variable_stiffness.py
@@ -12,7 +12,7 @@ Requirements:
 
 from crisp_py.robot import make_robot
 
-robot = make_robot("fr3")
+robot = make_robot("fr3_admittance")
 robot.wait_until_ready()
 
 # Switch to admittance controller


### PR DESCRIPTION
This PR accompanies https://github.com/utiasDSL/crisp_controllers/pull/47. Please see it for a detailed description of the problem and newly introduced functionality.

It:
 - Adds default admittance config
 - Updates Robot class for setting admittance stiffness parameters. Note that this is different from Cartesian admittance parameters (which still could be specified, but with another method -- see https://github.com/KAIST-IRiS-Haptics-Telerobotics/crisp_py/pull/2)
 - Adds an example for running the admittance controller with different admittance stiffnesses

Thanks to @lvjonok for participating in the discussion and preliminary code review