### PR TITLE
chore: update docs to reflect state_broadcaster implementation

### DIFF
--- a/docs/how_to_crisp.md
+++ b/docs/how_to_crisp.md
@@ -39,7 +39,7 @@ This will display a list of available controllers and their state:
 cartesian_impedance_controller: inactive
 gravity_compensation: inactive
 joint_state_broadcaster: active
-pose_broadcaster: active
+state_broadcaster: active
 joint_trajectory_controller: active
 ```
 
@@ -56,7 +56,7 @@ If you list the available controllers again you will see:
 cartesian_impedance_controller: active
 gravity_compensation: inactive
 joint_state_broadcaster: active
-pose_broadcaster: active
+state_broadcaster: active
 joint_trajectory_controller: inactive
 ```
 


### PR DESCRIPTION
As far as I can tell, only documentation needed to be updated for the [state broadcaster implementation](https://github.com/learnsyslab/crisp_controllers_demos/issues/new)

The robot subscribes to  the same default topics as before, which were carried over to `state_broadcaster`