### PR TITLE
feat!: vector-valued nullspace params

### DIFF
--- a/config/control/clipped_cartesian_impedance.yaml
+++ b/config/control/clipped_cartesian_impedance.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/config/control/default_cartesian_impedance.yaml
+++ b/config/control/default_cartesian_impedance.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/config/control/default_operational_space_controller.yaml
+++ b/config/control/default_operational_space_controller.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/config/control/dynaarm_cic_soft.yaml
+++ b/config/control/dynaarm_cic_soft.yaml
@@ -22,17 +22,11 @@ log.timing: false
 max_delta_tau: 0.5
 noise.add_random_noise: false
 noise.amplitude: 0.0
-nullspace.damping: 1.0
-nullspace.max_tau: 5.0
+nullspace.damping: [0.0]
+nullspace.max_tau: [5.0]
 nullspace.projector_type: none
 nullspace.regularization: 1.0e-06
-nullspace.stiffness: 0.0
-nullspace.weights.elbow_flexion.value: 0.0
-nullspace.weights.forearm_rotation.value: 0.0
-nullspace.weights.shoulder_flexion.value: 0.0
-nullspace.weights.shoulder_rotation.value: 0.0
-nullspace.weights.wrist_flexion.value: 0.0
-nullspace.weights.wrist_rotation.value: 0.0
+nullspace.stiffness: [0.0]
 operational_space_regularization: 1.0
 stop_commands: false
 

--- a/config/control/dynaarm_gravity.yaml
+++ b/config/control/dynaarm_gravity.yaml
@@ -9,11 +9,11 @@ log.enabled: false
 
 max_delta_tau: 0.5
 
-nullspace.damping: -1.0
-nullspace.max_tau: 5.0
+nullspace.damping: [-1.0]
+nullspace.max_tau: [5.0]
 nullspace.projector_type: none
 nullspace.regularization: 1.0e-06
-nullspace.stiffness: 0.0
+nullspace.stiffness: [0.0]
 
 operational_space_regularization: 1.0
 stop_commands: false

--- a/config/control/gravity_compensation.yaml
+++ b/config/control/gravity_compensation.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/config/control/gravity_compensation_on_fix_position.yaml
+++ b/config/control/gravity_compensation_on_fix_position.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/config/control/gravity_compensation_on_plane.yaml
+++ b/config/control/gravity_compensation_on_plane.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/config/control/joint_control.yaml
+++ b/config/control/joint_control.yaml
@@ -5,17 +5,10 @@ max_delta_tau: 0.5
 
 nullspace.projector_type: none  # So we are directly controlling the joints!
 
-nullspace.stiffness: 5.0
-nullspace.damping: 1.0
-nullspace.max_tau: 5.0
+nullspace.stiffness: [75.0, 75.0, 40.0, 40.0, 40.0, 25.0, 25.0]
+nullspace.damping: [15.0, 15.0, 8.0, 8.0, 8.0, 5.0, 5.0]
+nullspace.max_tau: [5.0]
 nullspace.regularization: 1.0e-06
-nullspace.weights.right_fr3_joint1.value: 15.0
-nullspace.weights.right_fr3_joint2.value: 15.0
-nullspace.weights.right_fr3_joint3.value: 8.0
-nullspace.weights.right_fr3_joint4.value: 8.0
-nullspace.weights.right_fr3_joint5.value: 8.0
-nullspace.weights.right_fr3_joint6.value: 5.0
-nullspace.weights.right_fr3_joint7.value: 5.0
 
 stop_commands: false
 

--- a/config/control/joint_velocity_control.yaml
+++ b/config/control/joint_velocity_control.yaml
@@ -4,17 +4,10 @@ limit_torques: true
 max_delta_tau: 0.5
 
 nullspace.projector_type: none  # So we are directly controlling the joints!
-nullspace.stiffness: 0.0
-nullspace.damping: 10.0
-nullspace.max_tau: 5.0
+nullspace.stiffness: [0.0]
+nullspace.damping: [150.0, 150.0, 80.0, 80.0, 80.0, 50.0, 50.0]
+nullspace.max_tau: [5.0]
 nullspace.regularization: 1.0e-06
-nullspace.weights.right_fr3_joint1.value: 15.0
-nullspace.weights.right_fr3_joint2.value: 15.0
-nullspace.weights.right_fr3_joint3.value: 8.0
-nullspace.weights.right_fr3_joint4.value: 8.0
-nullspace.weights.right_fr3_joint5.value: 8.0
-nullspace.weights.right_fr3_joint6.value: 5.0
-nullspace.weights.right_fr3_joint7.value: 5.0
 
 stop_commands: false
 

--- a/config/control/no_friction_cartesian_impedance.yaml
+++ b/config/control/no_friction_cartesian_impedance.yaml
@@ -33,7 +33,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/crisp_py/config/control/clipped_cartesian_impedance.yaml
+++ b/crisp_py/config/control/clipped_cartesian_impedance.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/crisp_py/config/control/default_admittance.yaml
+++ b/crisp_py/config/control/default_admittance.yaml
@@ -4,7 +4,7 @@
 limit_error: true
 limit_torques: true
 max_delta_tau: 2.0
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 stop_commands: false
 
 task.k_pos_x: 900.0

--- a/crisp_py/config/control/default_cartesian_impedance.yaml
+++ b/crisp_py/config/control/default_cartesian_impedance.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/crisp_py/config/control/default_operational_space_controller.yaml
+++ b/crisp_py/config/control/default_operational_space_controller.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/crisp_py/config/control/gravity_compensation.yaml
+++ b/crisp_py/config/control/gravity_compensation.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/crisp_py/config/control/gravity_compensation_on_plane.yaml
+++ b/crisp_py/config/control/gravity_compensation_on_plane.yaml
@@ -3,7 +3,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/crisp_py/config/control/joint_control.yaml
+++ b/crisp_py/config/control/joint_control.yaml
@@ -5,17 +5,10 @@ max_delta_tau: 0.5
 
 nullspace.projector_type: none  # So we are directly controlling the joints!
 
-nullspace.stiffness: 5.0
-nullspace.damping: 1.0
-nullspace.max_tau: 5.0
+nullspace.stiffness: [75.0, 75.0, 40.0, 40.0, 40.0, 25.0, 25.0]
+nullspace.damping: [15.0, 15.0, 8.0, 8.0, 8.0, 5.0, 5.0]
+nullspace.max_tau: [5.0]
 nullspace.regularization: 1.0e-06
-nullspace.weights.right_fr3_joint1.value: 15.0
-nullspace.weights.right_fr3_joint2.value: 15.0
-nullspace.weights.right_fr3_joint3.value: 8.0
-nullspace.weights.right_fr3_joint4.value: 8.0
-nullspace.weights.right_fr3_joint5.value: 8.0
-nullspace.weights.right_fr3_joint6.value: 5.0
-nullspace.weights.right_fr3_joint7.value: 5.0
 
 stop_commands: false
 

--- a/crisp_py/config/control/joint_velocity_control.yaml
+++ b/crisp_py/config/control/joint_velocity_control.yaml
@@ -4,17 +4,10 @@ limit_torques: true
 max_delta_tau: 0.5
 
 nullspace.projector_type: none  # So we are directly controlling the joints!
-nullspace.stiffness: 0.0
-nullspace.damping: 10.0
-nullspace.max_tau: 5.0
+nullspace.stiffness: [0.0]
+nullspace.damping: [150.0, 150.0, 80.0, 80.0, 80.0, 50.0, 50.0]
+nullspace.max_tau: [5.0]
 nullspace.regularization: 1.0e-06
-nullspace.weights.right_fr3_joint1.value: 15.0
-nullspace.weights.right_fr3_joint2.value: 15.0
-nullspace.weights.right_fr3_joint3.value: 8.0
-nullspace.weights.right_fr3_joint4.value: 8.0
-nullspace.weights.right_fr3_joint5.value: 8.0
-nullspace.weights.right_fr3_joint6.value: 5.0
-nullspace.weights.right_fr3_joint7.value: 5.0
 
 stop_commands: false
 

--- a/crisp_py/config/control/no_friction_cartesian_impedance.yaml
+++ b/crisp_py/config/control/no_friction_cartesian_impedance.yaml
@@ -33,7 +33,7 @@ limit_torques: true
 
 max_delta_tau: 0.5
 
-nullspace.stiffness: 5.0
+nullspace.stiffness: [5.0]
 
 stop_commands: false
 

--- a/docs/how_to_crisp.md
+++ b/docs/how_to_crisp.md
@@ -73,7 +73,7 @@ params = [
     ("task.k_rot_x", 20.0),
     ("task.k_rot_y", 20.0),
     ("task.k_rot_z", 20.0),
-    ("nullspace.stiffness", 5.0),
+    ("nullspace.stiffness", [5.0]),
 ]
 
 robot.cartesian_controller_parameters_client.set_parameters(params)

--- a/examples/example_with_iiwa.py
+++ b/examples/example_with_iiwa.py
@@ -24,7 +24,7 @@ params = [
     ("task.k_rot_x", 80.0),
     ("task.k_rot_y", 80.0),
     ("task.k_rot_z", 80.0),
-    ("nullspace.stiffness", 5.0),
+    ("nullspace.stiffness", [5.0]),
 ]
 
 robot.cartesian_controller_parameters_client.set_parameters(params)


### PR DESCRIPTION
Migrates the shipped control configs to the vector-valued nullspace parameters introduced in [crisp_controllers#69](https://github.com/learnsyslab/crisp_controllers/pull/69).

**Requires crisp_controllers with #69 merged.** These configs will not load against older controllers, and vice versa.

## What changed upstream

`nullspace.stiffness`, `nullspace.damping` and `nullspace.max_tau` become `double_array` (length 1 to broadcast to every joint, or one entry per DoF), and `nullspace.weights.*` is removed entirely.

Old semantics:

```
diag(K) = stiffness_scalar * weights
diag(D) = damping_scalar * weights   if damping >= 0
        = 2 * sqrt(diag(K))          if damping < 0
max_tau = scalar, unweighted
```

So the migration multiplies the weights through into the gain vectors. Every config keeps its existing effective behaviour — no gains change value.

## Changes

| file | change |
|---|---|
| 14 configs with only `nullspace.stiffness: 5.0` | → `[5.0]` |
| `joint_control.yaml` (both copies) | stiffness → `[75.0, 75.0, 40.0, 40.0, 40.0, 25.0, 25.0]`, damping → `[15.0, 15.0, 8.0, 8.0, 8.0, 5.0, 5.0]`, max_tau → `[5.0]`, 7 weights keys dropped |
| `joint_velocity_control.yaml` (both copies) | stiffness → `[0.0]`, damping → `[150.0, 150.0, 80.0, 80.0, 80.0, 50.0, 50.0]`, max_tau → `[5.0]`, 7 weights keys dropped |
| `dynaarm_cic_soft.yaml` | all weights were `0.0`, so both gains collapse to `[0.0]`; max_tau → `[5.0]`, 6 weights keys dropped |
| `dynaarm_gravity.yaml` | no weights block, values pass through: `[0.0]` / `[-1.0]` / `[5.0]` |

Plus `docs/how_to_crisp.md` and `examples/example_with_iiwa.py`.

The widened upstream `element_bounds<>: [0.0, 100000.0]` is what makes the multiplied-through values legal — the old `[0.0, 500.0]` ceiling would have rejected them.

## Two things that bit during the migration

- **Stale `weights` keys hard-fail rather than being ignored.** `load_param_config` → `set_parameters` calls `get_parameters` first and raises `ValueError` on any absent name (`crisp_py/control/parameters_client.py:161`), so a leftover `nullspace.weights.*` line breaks env construction at startup. All of them are removed here.
- **Gains must be written as floats.** `Parameter(name, value=...)` infers the type from the Python value, so a YAML list like `[5, 5]` arrives as `INTEGER_ARRAY` and the node rejects it. All 32 migrated gain params were verified to parse as non-empty lists of `float`.

## crisp_gym

Checked — **no code or config change needed there.** It has zero references to `nullspace`/`stiffness`/`damping`/`max_tau` anywhere, and ships no `config/control/` directory. It only names control configs (`control/gravity_compensation.yaml`, `control/default_cartesian_impedance.yaml`, `control/joint_control.yaml`), which resolve through `find_config()` → `CRISP_CONFIG_PATHS`, whose first entry is `files("crisp_py")/config`. This PR fixes it for free.

Two follow-ups there, neither blocking:

- `crisp_gym/pyproject.toml` pins `crisp_python>=3.0.0,<4`. If this lands as crisp_py 4.0.0, that pin holds crisp_gym on the old configs against a new controller.
- Users with site-local control YAMLs on `CRISP_CONFIG_PATH` have to migrate them by hand — worth a changelog note.